### PR TITLE
Run-node-app-in-minikube-using-github-workflow

### DIFF
--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -30,11 +30,11 @@ jobs:
 
       - name: Install cri-dockerd
         run: |
-          git clone https://github.com/Mirantis/cri-dockerd.git
-          cd cri-dockerd
-          sudo make install
-          cd ..
-          rm -rf cri-dockerd
+          CRI_DOCKERD_VERSION=$(curl -s https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest | jq -r '.tag_name')
+          curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}-amd64.tar.gz"
+          sudo tar -C /usr/local/bin -xzf "cri-dockerd-${CRI_DOCKERD_VERSION}-amd64.tar.gz"
+          rm "cri-dockerd-${CRI_DOCKERD_VERSION}-amd64.tar.gz"
+          sudo chmod +x /usr/local/bin/cri-dockerd
 
       - name: Install Minikube
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -30,8 +30,11 @@ jobs:
 
       - name: Run using kubectl command
         run: |
+          IMAGE_NAME="$DOCKER_IMAGE_NAME:${{ github.sha }}"
+          sed -i "s/node-app:1.0/$IMAGE_NAME/" deployment.yaml
           kubectl apply -f deployment.yaml
           sleep 20
           kubectl get all
           kubectl describe pod $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
-          # kubectl logs $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
+          echo "-------------------------------------------------------------------------"
+          kubectl logs $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -42,10 +42,11 @@ jobs:
           curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
           sudo install minikube-linux-amd64 /usr/local/bin/minikube
 
-      - name: Ensure conntrack is in root path
+      - name: Ensure dependencies are in root path
         run: |
           sudo ln -s "$(which conntrack)" /usr/bin/conntrack || true
           sudo ln -s "$(which crictl)" /usr/bin/crictl || true
+          sudo ln -s "$(which cri-dockerd)" /usr/bin/cri-dockerd || true
 
       - name: Verify conntrack installation
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -21,13 +21,22 @@ jobs:
       - name: Install Dependencies for Minikube
         run: sudo apt-get update && sudo apt-get install -y conntrack
 
+      - name: Install crictl
+        run: |
+          VERSION="v1.28.0"
+          curl -LO "https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz"
+          sudo tar -C /usr/local/bin -xzf "crictl-$VERSION-linux-amd64.tar.gz"
+          rm "crictl-$VERSION-linux-amd64.tar.gz"
+
       - name: Install Minikube
         run: |
           curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
           sudo install minikube-linux-amd64 /usr/local/bin/minikube
 
       - name: Ensure conntrack is in root path
-        run: sudo ln -s "$(which conntrack)" /usr/bin/conntrack || true
+        run: |
+          sudo ln -s "$(which conntrack)" /usr/bin/conntrack || true
+          sudo ln -s "$(which crictl)" /usr/bin/crictl || true
 
       - name: Verify conntrack installation
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -30,11 +30,11 @@ jobs:
 
       - name: Install cri-dockerd
         run: |
-          VERSION="v0.3.16"
-          curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/$VERSION/cri-dockerd-$VERSION-amd64.tar.gz"
-          sudo tar -C /usr/local/bin -xzf "cri-dockerd-$VERSION-amd64.tar.gz"
-          rm "cri-dockerd-$VERSION-amd64.tar.gz"
-          sudo chmod +x /usr/local/bin/cri-dockerd
+          git clone https://github.com/Mirantis/cri-dockerd.git
+          cd cri-dockerd
+          sudo make install
+          cd ..
+          rm -rf cri-dockerd
 
       - name: Install Minikube
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   DOCKER_IMAGE_NAME: "node-app-project"
-  DOCKER_IMAGE_TAG: "S{{ github.sha }}"
+
 jobs:
   build-and-run:
     runs-on: ubuntu-latest
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build Dockerfile
-        run: docker build -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG .
+        run: docker build -t $DOCKER_IMAGE_NAME:${{ github.sha }} .
 
       - name: Install Minikube
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -18,17 +18,27 @@ jobs:
       - name: Build Dockerfile
         run: docker build -t $DOCKER_IMAGE_NAME:${{ github.sha }} .
 
-      # - name: Install Dependencies for Minikube
-      #   run: sudo apt-get update && sudo apt-get install -y conntrack
+      - name: Install Dependencies for Minikube
+        run: sudo apt-get update && sudo apt-get install -y conntrack
 
       - name: Install Minikube
         run: |
           curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
           sudo install minikube-linux-amd64 /usr/local/bin/minikube
 
+      - name: Ensure conntrack is in root path
+        run: sudo ln -s "$(which conntrack)" /usr/bin/conntrack || true
+
+      - name: Verify conntrack installation
+        run: |
+          which conntrack
+          sudo which conntrack
+          sudo conntrack --version
+
       - name: Start Minikube
         run: |
-          minikube start --driver=none
+          echo "Path: $PATH"
+          sudo env PATH=$PATH minikube start --driver=none
           minikube status
 
       - name: Install kubectl

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -29,13 +29,19 @@ jobs:
           rm "crictl-$VERSION-linux-amd64.tar.gz"
 
       - name: Install cri-dockerd
-        run: |
+        run: | 
           CRI_DOCKERD_VERSION=$(curl -s https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest | jq -r '.tag_name' | sed 's/v//')
           echo "CRI_DOCKERD_VERSION: $CRI_DOCKERD_VERSION"
           curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
           sudo tar -C /usr/local/bin -xzf "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
           rm "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
           sudo chmod +x /usr/local/bin/cri-dockerd
+
+      - name: Ensure cri-dockerd is in Root Path
+        run: |
+          sudo ln -sf /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd
+          ls -lh /usr/bin/cri-dockerd
+          which cri-dockerd
 
       - name: Install Minikube
         run: |
@@ -46,7 +52,7 @@ jobs:
         run: |
           sudo ln -s "$(which conntrack)" /usr/bin/conntrack || true
           sudo ln -s "$(which crictl)" /usr/bin/crictl || true
-          sudo ln -s "$(which cri-dockerd)" /usr/bin/cri-dockerd || true
+          # sudo ln -s "$(which cri-dockerd)" /usr/bin/cri-dockerd || true
 
       - name: Verify conntrack installation
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -28,13 +28,14 @@ jobs:
           sudo tar -C /usr/local/bin -xzf "crictl-$VERSION-linux-amd64.tar.gz"
           rm "crictl-$VERSION-linux-amd64.tar.gz"
 
-      - name: Install cri-dockerd manually
+      - name: Install cri-dockerd
         run: |
-          install -o root -g root -m 0755 cri-dockerd /usr/local/bin/cri-dockerd
-          install packaging/systemd/* /etc/systemd/system
-          sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
-          systemctl daemon-reload
-          systemctl enable --now cri-docker.socket
+          CRI_DOCKERD_VERSION=$(curl -s https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest | jq -r '.tag_name' | sed 's/v//')
+          echo "CRI_DOCKERD_VERSION: $CRI_DOCKERD_VERSION"
+          curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
+          sudo tar -C /usr/local/bin -xzf "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
+          rm "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
+          sudo chmod +x /usr/local/bin/cri-dockerd
 
       - name: Install Minikube
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Ensure cri-dockerd is in Root Path
         run: |
-          sudo ln -sf /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd
+          sudo ln -sf /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd || true
           ls -lh /usr/bin/cri-dockerd
           which cri-dockerd
 

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -33,3 +33,4 @@ jobs:
           kubectl apply -f deployment.yaml
           sleep 20
           kubectl get all
+          kubectl logs $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -18,6 +18,9 @@ jobs:
       - name: Build Dockerfile
         run: docker build -t $DOCKER_IMAGE_NAME:${{ github.sha }} .
 
+      - name: Install Dependencies for Minikube
+        run: sudo apt-get update && sudo apt-get install -y conntrack
+
       - name: Install Minikube
         run: |
           curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Build Dockerfile
         run: docker build -t $DOCKER_IMAGE_NAME:${{ github.sha }} .
 
-      - name: Install Dependencies for Minikube
-        run: sudo apt-get update && sudo apt-get install -y conntrack
+      # - name: Install Dependencies for Minikube
+      #   run: sudo apt-get update && sudo apt-get install -y conntrack
 
       - name: Install Minikube
         run: |
@@ -28,8 +28,8 @@ jobs:
 
       - name: Start Minikube
         run: |
-          sudo minikube start --driver=none
-          sudo minikube status
+          minikube start --driver=none
+          minikube status
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v4

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Load image to minikube
         run: |
           minikube image load ${{ env.IMAGE_NAME }}
-          echo "Loaded image"
+          echo -e "Loaded image ${{ env.IMAGE_NAME }} to minikube.\nListing all images:"
           minikube image ls
 
       - name: Run using kubectl command
@@ -44,6 +44,7 @@ jobs:
       
       - name: Print pod and container log
         run: |
+          POD_NAME=$(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
           echo "-------------------------------------------------------------------------"
           echo "POD LOG:"          
           kubectl logs $POD_NAME

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -15,26 +15,37 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Build Dockerfile
-        run: docker build -t $DOCKER_IMAGE_NAME:${{ github.sha }} .
+      - name: Build Docker Image
+        run: |
+          IMAGE_NAME="$DOCKER_IMAGE_NAME:${{ github.sha }}"
+          echo "IMAGE_NAME=$IMAGE_NAME"
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+          docker build -t ${{ env.IMAGE_NAME }} .
 
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
 
       - name: Load image to minikube
         run: |
-          minikube image ls
-          minikube image load $DOCKER_IMAGE_NAME:${{ github.sha }}
+          minikube image load ${{ env.IMAGE_NAME }}
           echo "Loaded image"
           minikube image ls
 
       - name: Run using kubectl command
         run: |
-          IMAGE_NAME="$DOCKER_IMAGE_NAME:${{ github.sha }}"
-          sed -i "s/node-app:1.0/$IMAGE_NAME/" deployment.yaml
+          sed -i "s/node-app:1.0/${{ env.IMAGE_NAME }}/" deployment.yaml
           kubectl apply -f deployment.yaml
-          sleep 20
+          sleep 30
           kubectl get all
-          kubectl describe pod $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
+          POD_NAME=$(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
+          kubectl describe pod $POD_NAME
+      
+      - name: Print pod and container log
+        run: |
           echo "-------------------------------------------------------------------------"
-          kubectl logs $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
+          echo "POD LOG:"          
+          kubectl logs $POD_NAME
+          echo "-------------------------------------------------------------------------"
+          echo "CONTAINER LOG"
+          kubectl exec -it $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}') -- curl http://localhost:3000
+          echo "-------------------------------------------------------------------------"

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -42,7 +42,7 @@ jobs:
           POD_NAME=$(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
           kubectl describe pod $POD_NAME
       
-      - name: Print pod and container log
+      - name: Print pod logs
         run: |
           POD_NAME=$(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
           echo "-------------------------------------------------------------------------"

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -18,63 +18,71 @@ jobs:
       - name: Build Dockerfile
         run: docker build -t $DOCKER_IMAGE_NAME:${{ github.sha }} .
 
-      - name: Install Dependencies for Minikube
-        run: sudo apt-get update && sudo apt-get install -y conntrack
+      # - name: Install Dependencies for Minikube
+      #   run: sudo apt-get update && sudo apt-get install -y conntrack
 
-      - name: Install crictl
-        run: |
-          VERSION="v1.28.0"
-          curl -LO "https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz"
-          sudo tar -C /usr/local/bin -xzf "crictl-$VERSION-linux-amd64.tar.gz"
-          rm "crictl-$VERSION-linux-amd64.tar.gz"
+      # - name: Install crictl
+      #   run: |
+      #     VERSION="v1.28.0"
+      #     curl -LO "https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz"
+      #     sudo tar -C /usr/local/bin -xzf "crictl-$VERSION-linux-amd64.tar.gz"
+      #     rm "crictl-$VERSION-linux-amd64.tar.gz"
 
-      - name: Install cri-dockerd
-        run: | 
-          CRI_DOCKERD_VERSION=$(curl -s https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest | jq -r '.tag_name' | sed 's/v//')
-          echo "CRI_DOCKERD_VERSION: $CRI_DOCKERD_VERSION"
-          curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
-          sudo tar -C /usr/local/bin -xzf "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
-          rm "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
-          sudo chmod +x /usr/local/bin/cri-dockerd
+      # - name: Install cri-dockerd
+      #   run: | 
+      #     CRI_DOCKERD_VERSION=$(curl -s https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest | jq -r '.tag_name' | sed 's/v//')
+      #     echo "CRI_DOCKERD_VERSION: $CRI_DOCKERD_VERSION"
+      #     curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
+      #     sudo tar -C /usr/local/bin -xzf "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
+      #     rm "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
+      #     sudo chmod +x /usr/local/bin/cri-dockerd
 
-      - name: Ensure cri-dockerd is in Root Path
-        run: |
-          sudo ln -sf /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd || true
-          ls -lh /usr/bin/cri-dockerd
-          which cri-dockerd
+      # - name: Ensure cri-dockerd is in Root Path
+      #   run: |
+      #     sudo ln -sf /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd || true
+      #     ls -lh /usr/bin/cri-dockerd
+      #     which cri-dockerd
 
-      - name: Install Minikube
-        run: |
-          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-          sudo install minikube-linux-amd64 /usr/local/bin/minikube
+      # - name: Install Minikube
+      #   run: |
+      #     curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+      #     sudo install minikube-linux-amd64 /usr/local/bin/minikube
 
-      - name: Ensure dependencies are in root path
-        run: |
-          sudo ln -s "$(which conntrack)" /usr/bin/conntrack || true
-          sudo ln -s "$(which crictl)" /usr/bin/crictl || true
-          # sudo ln -s "$(which cri-dockerd)" /usr/bin/cri-dockerd || true
+      # - name: Ensure dependencies are in root path
+      #   run: |
+      #     sudo ln -s "$(which conntrack)" /usr/bin/conntrack || true
+      #     sudo ln -s "$(which crictl)" /usr/bin/crictl || true
+      #     # sudo ln -s "$(which cri-dockerd)" /usr/bin/cri-dockerd || true
 
-      - name: Verify conntrack installation
-        run: |
-          which conntrack
-          sudo which conntrack
-          sudo conntrack --version
+      # - name: Verify conntrack installation
+      #   run: |
+      #     which conntrack
+      #     sudo which conntrack
+      #     sudo conntrack --version
 
-      - name: Start Minikube
-        run: |
-          echo "Path: $PATH"
-          sudo env PATH=$PATH minikube start --driver=none
-          minikube status
+      # - name: Start Minikube
+      #   run: |
+      #     echo "Path: $PATH"
+      #     sudo env PATH=$PATH minikube start --driver=none
+      #     minikube status
 
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: 'v1.31.0' # default is latest stable
-        id: install
+      # - name: Install kubectl
+      #   uses: azure/setup-kubectl@v4
+      #   with:
+      #     version: 'v1.31.0' # default is latest stable
+      #   id: install
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@latest
+
+      - name: Try the cluster!
+        run: kubectl get pods -A
+
+      - name: Load image to minikube
+        run: minikube image load $DOCKER_IMAGE_NAME:${{ github.sha }}
 
       - name: Run using kubectl command
         run: |
-          kubectl get nodes
           kubectl apply -f deployment.yaml
-          sleep 20
+          sleep 30
           kubectl get all

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -28,13 +28,13 @@ jobs:
           sudo tar -C /usr/local/bin -xzf "crictl-$VERSION-linux-amd64.tar.gz"
           rm "crictl-$VERSION-linux-amd64.tar.gz"
 
-      - name: Install cri-dockerd
+      - name: Install cri-dockerd manually
         run: |
-          CRI_DOCKERD_VERSION=$(curl -s https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest | jq -r '.tag_name')
-          curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}-amd64.tar.gz"
-          sudo tar -C /usr/local/bin -xzf "cri-dockerd-${CRI_DOCKERD_VERSION}-amd64.tar.gz"
-          rm "cri-dockerd-${CRI_DOCKERD_VERSION}-amd64.tar.gz"
-          sudo chmod +x /usr/local/bin/cri-dockerd
+          install -o root -g root -m 0755 cri-dockerd /usr/local/bin/cri-dockerd
+          install packaging/systemd/* /etc/systemd/system
+          sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
+          systemctl daemon-reload
+          systemctl enable --now cri-docker.socket
 
       - name: Install Minikube
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -31,9 +31,10 @@ jobs:
       - name: Install cri-dockerd
         run: |
           VERSION="v0.3.16"
-          curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/$VERSION/cri-dockerd-$VERSION.amd64.tgz"
-          sudo tar -C /usr/local/bin -xzf "cri-dockerd-$VERSION.amd64.tgz"
-          rm "cri-dockerd-$VERSION.amd64.tgz"
+          curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/$VERSION/cri-dockerd-$VERSION-amd64.tar.gz"
+          sudo tar -C /usr/local/bin -xzf "cri-dockerd-$VERSION-amd64.tar.gz"
+          rm "cri-dockerd-$VERSION-amd64.tar.gz"
+          sudo chmod +x /usr/local/bin/cri-dockerd
 
       - name: Install Minikube
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -49,6 +49,3 @@ jobs:
           echo "POD LOG:"          
           kubectl logs $POD_NAME
           echo "-------------------------------------------------------------------------"
-          echo "CONTAINER LOG"
-          kubectl exec -it $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}') -- curl http://localhost:3000
-          echo "-------------------------------------------------------------------------"

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -28,6 +28,13 @@ jobs:
           sudo tar -C /usr/local/bin -xzf "crictl-$VERSION-linux-amd64.tar.gz"
           rm "crictl-$VERSION-linux-amd64.tar.gz"
 
+      - name: Install cri-dockerd
+        run: |
+          VERSION="v0.3.16"
+          curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/$VERSION/cri-dockerd-$VERSION.amd64.tgz"
+          sudo tar -C /usr/local/bin -xzf "cri-dockerd-$VERSION.amd64.tgz"
+          rm "cri-dockerd-$VERSION.amd64.tgz"
+
       - name: Install Minikube
         run: |
           curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -33,4 +33,5 @@ jobs:
           kubectl apply -f deployment.yaml
           sleep 20
           kubectl get all
-          kubectl logs $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
+          kubectl describe pod $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')
+          # kubectl logs $(kubectl get pod --selector app=node-app -o=jsonpath='{.items[0].metadata.name}{"\n"}')

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -15,13 +15,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Build Docker Image
+      - name: Generate Image Tag
         run: |
           IMAGE_NAME="$DOCKER_IMAGE_NAME:${{ github.sha }}"
           echo "IMAGE_NAME=$IMAGE_NAME"
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
-          docker build -t ${{ env.IMAGE_NAME }} .
 
+      - name: Build Docker image
+        run: docker build -t ${{ env.IMAGE_NAME }} .
+          
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
 

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -18,71 +18,18 @@ jobs:
       - name: Build Dockerfile
         run: docker build -t $DOCKER_IMAGE_NAME:${{ github.sha }} .
 
-      # - name: Install Dependencies for Minikube
-      #   run: sudo apt-get update && sudo apt-get install -y conntrack
-
-      # - name: Install crictl
-      #   run: |
-      #     VERSION="v1.28.0"
-      #     curl -LO "https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz"
-      #     sudo tar -C /usr/local/bin -xzf "crictl-$VERSION-linux-amd64.tar.gz"
-      #     rm "crictl-$VERSION-linux-amd64.tar.gz"
-
-      # - name: Install cri-dockerd
-      #   run: | 
-      #     CRI_DOCKERD_VERSION=$(curl -s https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest | jq -r '.tag_name' | sed 's/v//')
-      #     echo "CRI_DOCKERD_VERSION: $CRI_DOCKERD_VERSION"
-      #     curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
-      #     sudo tar -C /usr/local/bin -xzf "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
-      #     rm "cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
-      #     sudo chmod +x /usr/local/bin/cri-dockerd
-
-      # - name: Ensure cri-dockerd is in Root Path
-      #   run: |
-      #     sudo ln -sf /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd || true
-      #     ls -lh /usr/bin/cri-dockerd
-      #     which cri-dockerd
-
-      # - name: Install Minikube
-      #   run: |
-      #     curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-      #     sudo install minikube-linux-amd64 /usr/local/bin/minikube
-
-      # - name: Ensure dependencies are in root path
-      #   run: |
-      #     sudo ln -s "$(which conntrack)" /usr/bin/conntrack || true
-      #     sudo ln -s "$(which crictl)" /usr/bin/crictl || true
-      #     # sudo ln -s "$(which cri-dockerd)" /usr/bin/cri-dockerd || true
-
-      # - name: Verify conntrack installation
-      #   run: |
-      #     which conntrack
-      #     sudo which conntrack
-      #     sudo conntrack --version
-
-      # - name: Start Minikube
-      #   run: |
-      #     echo "Path: $PATH"
-      #     sudo env PATH=$PATH minikube start --driver=none
-      #     minikube status
-
-      # - name: Install kubectl
-      #   uses: azure/setup-kubectl@v4
-      #   with:
-      #     version: 'v1.31.0' # default is latest stable
-      #   id: install
-
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
 
-      - name: Try the cluster!
-        run: kubectl get pods -A
-
       - name: Load image to minikube
-        run: minikube image load $DOCKER_IMAGE_NAME:${{ github.sha }}
+        run: |
+          minikube image ls
+          minikube image load $DOCKER_IMAGE_NAME:${{ github.sha }}
+          echo "Loaded image"
+          minikube image ls
 
       - name: Run using kubectl command
         run: |
           kubectl apply -f deployment.yaml
-          sleep 30
+          sleep 20
           kubectl get all

--- a/Notes.txt
+++ b/Notes.txt
@@ -9,5 +9,10 @@ Part of: netfilter/iptables framework in Linux
 Command-line tool: conntrack
 Kernel module: nf_conntrack
 
+crictl is needed to interact with container runtimes (like containerd or CRI-O) in Kubernetes.
+Minikube requires crictl when using the none driver because it directly runs Kubernetes processes on the host.
+
+Since Minikube uses Docker as the container runtime, we must install cri-dockerd, which acts as an interface between Kubernetes and Docker.
+
 
 

--- a/Notes.txt
+++ b/Notes.txt
@@ -13,6 +13,7 @@ crictl is needed to interact with container runtimes (like containerd or CRI-O) 
 Minikube requires crictl when using the none driver because it directly runs Kubernetes processes on the host.
 
 Since Minikube uses Docker as the container runtime, we must install cri-dockerd, which acts as an interface between Kubernetes and Docker.
+Install cri-dockerd manually: https://mirantis.github.io/cri-dockerd/usage/install-manually/
 
 
 

--- a/Notes.txt
+++ b/Notes.txt
@@ -2,5 +2,12 @@ npm init -y --> adds package.json
 npm install express --> adds package-lock.json and node-modules/
 minikube image load <image-name> to run docker images locally
 
+The conntrack package is a network connection tracking tool that interacts with netfilter (Linux's built-in firewall system). It helps manage stateful packet filtering and connection tracking for NAT (Network Address Translation) and firewall rules.
+
+Full Name: Connection Tracking Utility
+Part of: netfilter/iptables framework in Linux
+Command-line tool: conntrack
+Kernel module: nf_conntrack
+
 
 

--- a/app.js
+++ b/app.js
@@ -7,5 +7,5 @@ app.get('/', (req, res) => {
 });
 
 app.listen(port, () => {
-  console.log(`App running on port ${port}`);
+  console.log(`Hello from the other side, you've reached pod logs. Your app is running on port ${port}`);
 });


### PR DESCRIPTION
Workflow Features:

- Builds docker image and updates tag dynamically in deploymnent manifest
- setup of minikube inside github workflow
- loading the docker built image to minikube
- creating the deployment in minikube as per deployment.yaml
- print the pod logs in the workflow console logs

![image](https://github.com/user-attachments/assets/f87642b8-9442-4d56-96c1-419bbd11b8d4)

![image](https://github.com/user-attachments/assets/1260c1ee-41cb-4ddb-8825-becc4f85f11e)

Tested run: https://github.com/cloud-sky-ops/node-app/actions/runs/14035137580/job/39291345890
