### PR TITLE
Implement argocd in cli

### DIFF
--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Generate Image Tag
         run: |
@@ -90,7 +92,7 @@ jobs:
           fi
 
           portForwardingPid=$(ps aux | grep "kubectl port-forward svc/argocd-server 8080:443 -n argocd" | grep -v "grep" | awk -F " " '{print $2}')
-          echo "PID for port-forwarding: portForwardingPid"
+          echo "PID for port-forwarding: $portForwardingPid"
           echo "-------------------------------------------------------------------------"
           yes | argocd login localhost:8080 --username admin --password $(argocd admin initial-password -n argocd | head -n 1)
           echo "-------------------------------------------------------------------------"

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -79,17 +79,32 @@ jobs:
 
       - name: Create and print argo application
         run: |
-          kubectl port-forward svc/argocd-server 8080:443 -n argocd
+          kubectl port-forward svc/argocd-server 8080:443 -n argocd > port-forward.log 2>&1 &
+          sleep 3
+          if ! grep -q "Forwarding from" port-forward.log; then
+            echo "Port forwarding failed, check logs."
+            cat port-forward.log
+            exit 1
+          fi
 
+          portForwardingPid=$(ps aux | grep "kubectl port-forward svc/argocd-server 8080:443 -n argocd" | grep -v "grep" | awk -F " " '{print $2}')
+          echo "PID for port-forwarding: portForwardingPid"
+          echo "-------------------------------------------------------------------------"
           yes | argocd login localhost:8080 --username admin --password $(argocd admin initial-password -n argocd | head -n 1)
+          echo "-------------------------------------------------------------------------"
 
           argocd app create node-project-application \
           --sync-policy auto --sync-option Prune=false  \
           --release-name testing-on-minikube \
           --repo https://github.com/cloud-sky-ops/node-app.git --path node-app-helm \
           --dest-namespace default --dest-server https://kubernetes.default.svc
+          echo "-------------------------------------------------------------------------"
 
           kubectl get application node-project-application -n argocd -o yaml
+          echo "-------------------------------------------------------------------------"
+
+          kill $portForwardingPid
+          rm -rf port-forward.log
 
       - name: Run kubectl commands for validation
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -17,7 +17,10 @@ jobs:
 
       - name: Generate Image Tag
         run: |
-          IMAGE_NAME="$DOCKER_IMAGE_NAME:${{ github.sha }}"
+          IMAGE_TAG="${{ github.sha }}"
+          IMAGE_NAME="$DOCKER_IMAGE_NAME:$IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
           echo "IMAGE_NAME=$IMAGE_NAME"
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
 
@@ -38,17 +41,39 @@ jobs:
         with:
           version: '3.13.1' # default is latest (stable)
 
+      - name: Update image tag in values YAML using yq
+        run: IMAGE_TAG=${{ env.IMAGE_TAG }} yq -i eval '.image.tag=env(IMAGE_TAG)' node-app-helm/values.yaml
+
       - name: Print rendered manifests in logs
         run: |
-          helm template node-app-helm/ \
-          --set image.tag="${{ github.sha }}" \
-          --set image.repository="$DOCKER_IMAGE_NAME"
+          helm template node-app-helm/
 
-      - name: Install helm chart
+      # https://argo-cd.readthedocs.io/en/stable/getting_started/#1-install-argo-cd
+      - name: Install Argo CD
         run: |
-          helm install testing-on-minikube node-app-helm/ \
-          --set image.tag="${{ github.sha }}" \
-          --set image.repository="$DOCKER_IMAGE_NAME"
+          kubectl create namespace argocd
+          kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+      # https://argo-cd.readthedocs.io/en/stable/cli_installation/#download-with-curl
+      - name: Install argocd cli 
+        run: |
+          curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+          sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
+          rm argocd-linux-amd64
+
+      - name: Create and print argo application
+        run: |
+          kubectl port-forward svc/argocd-server 8080:443 -n argocd
+
+          yes | argocd login localhost:8080 --username admin --password $(argocd admin initial-password -n argocd | head -n 1)
+
+          argocd app create node-project-application \
+          --sync-policy auto --sync-option Prune=false  \
+          --release-name testing-on-minikube \
+          --repo https://github.com/cloud-sky-ops/node-app.git --path node-app-helm \
+          --dest-namespace default --dest-server https://kubernetes.default.svc
+
+          kubectl get application node-project-application -n argocd -o yaml
 
       - name: Run kubectl commands for validation
         run: |

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -41,8 +41,10 @@ jobs:
         with:
           version: '3.13.1' # default is latest (stable)
 
-      - name: Update image tag in values YAML using yq
-        run: IMAGE_TAG=${{ env.IMAGE_TAG }} yq -i eval '.image.tag=env(IMAGE_TAG)' node-app-helm/values.yaml
+      - name: Update image tag in values nad Chart YAML using yq
+        run: |
+          IMAGE_TAG=${{ env.IMAGE_TAG }} yq -i eval '.image.tag=env(IMAGE_TAG)' node-app-helm/values.yaml
+          IMAGE_TAG=${{ env.IMAGE_TAG }} yq -i eval '.appVersion=env(IMAGE_TAG)' node-app-helm/Chart.yaml
 
       - name: Print rendered manifests in logs
         run: |
@@ -64,7 +66,7 @@ jobs:
       - name: Check if all pods are in "Running" state
         run: |
           while true; do
-            echo -e "Print current status of Argo CD Pods:\n"
+            echo -e "Printing current status of Argo CD Pods:\n"
             kubectl get pods -n argocd
             POD_STATUSES=$(kubectl get pods -n argocd -o=jsonpath='{.items[*].status.phase}')
             echo "POD_STATUSES: $POD_STATUSES"

--- a/.github/workflows/build-and-run.yaml
+++ b/.github/workflows/build-and-run.yaml
@@ -61,6 +61,22 @@ jobs:
           sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
           rm argocd-linux-amd64
 
+      - name: Check if all pods are in "Running" state
+        run: |
+          while true; do
+            echo -e "Print current status of Argo CD Pods:\n"
+            kubectl get pods -n argocd
+            POD_STATUSES=$(kubectl get pods -n argocd -o=jsonpath='{.items[*].status.phase}')
+            echo "POD_STATUSES: $POD_STATUSES"
+            if [[ $(echo "$POD_STATUSES" | tr ' ' '\n' | sort -u) == "Running" ]]; then
+                echo "All pods are in Running state."
+                break
+            else
+                echo "Waiting for all pods to be in Running state...Re-checking in 30 seconds"
+                sleep 30
+            fi
+          done
+
       - name: Create and print argo application
         run: |
           kubectl port-forward svc/argocd-server 8080:443 -n argocd

--- a/node-app-helm/values.yaml
+++ b/node-app-helm/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: node-app
+  repository: node-app-project
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
This PR creates a mechanism to install and run Argo CD inside GitHub Workflow:

- Hard code image path in values.yaml
- Dynamically Update image tag via yq command in values.yaml and Chart.yaml for Argocd to pick while rendering helm templates


![image](https://github.com/user-attachments/assets/211a1c93-8c3c-4b39-bc1d-5afb9ba82ea5)

- Install Argo CD and programmatically verify all pods are up and running in the argocd namespace


![image](https://github.com/user-attachments/assets/910635a8-dfcf-4728-b270-cbb2508aed49)

- Run argocd/server in the backgroud in workflow so terminal isn't blocked
- Install and utilize argocd cli to create app using helm chart directory


![image](https://github.com/user-attachments/assets/e6594e0e-9d1a-4321-aaa1-068884b42737)

And finally the pods logs will be available in the run against main branch as default branch is automatically set as source repo HEAD in argocd

Test run: https://github.com/cloud-sky-ops/node-app/actions/runs/14130180081